### PR TITLE
feat: dynamic route for event[id] with mockData

### DIFF
--- a/src/app/(pages)/events/[id]/eventMockData.ts
+++ b/src/app/(pages)/events/[id]/eventMockData.ts
@@ -1,0 +1,49 @@
+const eventMockData = [
+    {id: 1, 
+    name: 'Evento 1',
+    startDate: new Date().toISOString,
+    endDate: new Date().toISOString,
+    description: 'Evento Muito legal!!',
+    adress: 'Rio de Janeiro',
+    status: 'active',
+    producer: '123 Produções',
+    createAt: new Date().toISOString,
+    updatedAt: new Date().toISOString
+},
+{id: 2, 
+    name: 'Evento 2',
+    startDate: new Date().toISOString,
+    endDate: new Date().toISOString,
+    description: 'Evento Muito legalddd!!',
+    adress: 'SP ',
+    status: 'active',
+    producer: '123 Produções',
+    createAt: new Date().toISOString,
+    updatedAt: new Date().toISOString
+},
+{id: 3, 
+    name: 'Evento 3',
+    startDate: new Date().toISOString,
+    endDate: new Date().toISOString,
+    description: 'Evento Muito legal!!123123',
+    adress: 'MG',
+    status: 'active',
+    producer: '123 Produções',
+    createAt: new Date().toISOString,
+    updatedAt: new Date().toISOString
+},
+{id: 4, 
+    name: 'Evento 4',
+    startDate: new Date().toISOString,
+    endDate: new Date().toISOString,
+    description: 'Evento Muito legal!!',
+    adress: 'Acre',
+    status: 'active',
+    producer: '123 Produções',
+    createAt: new Date().toISOString,
+    updatedAt: new Date().toISOString
+}
+]
+
+
+export default eventMockData;

--- a/src/app/(pages)/events/[id]/page.tsx
+++ b/src/app/(pages)/events/[id]/page.tsx
@@ -1,0 +1,21 @@
+import eventMockData from "./eventMockData";
+
+export function getEventData(id: string) {
+
+    const event = eventMockData.filter((i) => i.id === Number(id));
+    return event[0];
+    
+}
+
+export default function EventPage({ params }: { params: { id: string } }) {
+
+    const event = getEventData(params.id);
+
+
+    return (
+    <div>
+        {!event && <p>Evento não encontrado</p>}
+        {event && event.name}
+    </div>
+    )
+}


### PR DESCRIPTION
Nesse commit, eu fiz as rotas dinâmicas /event/:id, onde o Id será o Id do evento e a página renderizada será após uma busca do evneto com o Id especificado na rota